### PR TITLE
Initial SSL specs (and fixes to the current implementation)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ bundler_args: --without development doc
 
 rvm:
   - 2.2
-  - 2.3.1
-  - jruby-9.0.5.0
+  - 2.3.3
+  - jruby-9.1.5.0
 
 matrix:
   fast_finish: true

--- a/spec/socketry/ssl/socket_spec.rb
+++ b/spec/socketry/ssl/socket_spec.rb
@@ -1,11 +1,105 @@
 # frozen_string_literal: true
 
 RSpec.describe Socketry::SSL::Socket do
+  let(:remote_host) { "localhost" }
+  let(:remote_port) { unoccupied_port(addr: remote_host) }
+
+  let(:ssl_server) do
+    tcp_server = ::TCPServer.new(remote_host, remote_port)
+    ssl_context = OpenSSL::SSL::SSLContext.new
+
+    ssl_context.cert = OpenSSL::X509::Certificate.new(server_cert_file.read)
+    ssl_context.key  = OpenSSL::PKey::RSA.new(server_key_file.read)
+
+    OpenSSL::SSL::SSLServer.new(tcp_server, ssl_context)
+  end
+
+  let(:ssl_client_params) do
+    { ca_file: ssl_cert_path("trusted-ca").to_s }
+  end
+
+  let(:ssl_server_thread) do
+    # Create the ssl_server
+    ssl_server
+
+    thread = Thread.new { ssl_server.accept rescue nil }
+    Thread.pass while thread.status && thread.status != "sleep"
+
+    thread
+  end
+
+  let(:ssl_peer_socket) { ssl_server_thread.value }
+
   describe ".initialize" do
     it "raises if given bogus :ssl_params" do
       expect { described_class.new(ssl_params: "polly shouldn't be!") }.to raise_error(TypeError)
     end
   end
 
-  it "needs way more tests!"
+  describe "#connect" do
+    subject(:ssl_socket) { described_class.new(ssl_params: ssl_client_params) }
+
+    before { ssl_server_thread }
+
+    after do
+      ssl_server_thread.kill if ssl_server_thread.alive?
+
+      ssl_socket.close rescue nil
+      ssl_server.close rescue nil
+      ssl_peer_socket.close rescue nil
+    end
+
+    context "with a valid CA" do
+      let(:server_cert_file) { ssl_cert_path("trusted-cert") }
+      let(:server_key_file)  { ssl_key_path("trusted-cert") }
+
+      it "connects to SSL servers" do
+        expect(ssl_socket.connect(remote_host, remote_port)).to be_a described_class
+        expect(ssl_peer_socket).to be_a OpenSSL::SSL::SSLSocket
+      end
+    end
+
+    context "with an invalid CA" do
+      let(:server_cert_file) { ssl_cert_path("untrusted-cert") }
+      let(:server_key_file)  { ssl_key_path("untrusted-cert") }
+
+      it "raises an exception" do
+        expect do
+          ssl_socket.connect(remote_host, remote_port)
+        end.to raise_error(Socketry::SSL::Error)
+      end
+    end
+
+    pending "raises Socketry::ConnectionRefusedError if a connection was refused"
+  end
+
+  describe "#reconnect" do
+    it "needs tests!"
+  end
+
+  describe "#from_socket" do
+    it "needs tests!"
+  end
+
+  context "stream socket specs" do
+    let(:server_cert_file) { ssl_cert_path("trusted-cert") }
+    let(:server_key_file)  { ssl_key_path("trusted-cert") }
+
+    subject(:stream_socket) { described_class.new(ssl_params: ssl_client_params) }
+    subject(:peer_socket) { ssl_peer_socket }
+
+    before do
+      ssl_server_thread
+      stream_socket.connect(remote_host, remote_port)
+    end
+
+    after do
+      ssl_server_thread.kill if ssl_server_thread.alive?
+
+      peer_socket.close rescue nil
+      ssl_server.close rescue nil
+    end
+
+    it_behaves_like "Socketry stream socket"
+  end
 end

--- a/spec/socketry/tcp/socket_spec.rb
+++ b/spec/socketry/tcp/socket_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Socketry::TCP::Socket do
   let(:mock_server) { ::TCPServer.new(remote_host, remote_port) }
   let(:peer_socket) { mock_server.accept }
 
-  let(:example_data) { "Hello, peer!" }
-
   before do
     mock_server
     stream_socket.connect(remote_host, remote_port)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,78 @@ RSpec.shared_examples "Socketry DNS resolver" do
   end
 end
 
+RSpec.shared_examples "Socketry stream socket" do
+  let(:example_data) { "Hello, peer!" }
+
+  context "non-blocking I/O" do
+    describe "#read_nonblock" do
+      it "reads data if available" do
+        peer_socket.write(example_data)
+        peer_socket.close
+        sleep 0.001 # :( sleeps like this are bad, but writing reliable I/O tests is hard
+
+        expect(stream_socket.read_nonblock(example_data.size)).to eq example_data
+      end
+
+      it "returns :wait_readable if we aren't ready to read" do
+        expect(stream_socket.read_nonblock(1)).to eq :wait_readable
+      end
+    end
+
+    describe "#write_nonblock" do
+      it "returns the number of bytes written on success" do
+        expect(stream_socket.write_nonblock(example_data)).to eq example_data.size
+      end
+
+      pending "returns :wait_writable if we aren't ready to write"
+    end
+  end
+
+  context "blocking reads" do
+    describe "#readpartial" do
+      it "reads partial data" do
+        peer_socket.write(example_data)
+        peer_socket.close
+
+        # TODO: test the case the read is actually partial
+        expect(stream_socket.readpartial(example_data.size)).to eq example_data
+      end
+    end
+
+    describe "#read" do
+      it "reads complete data" do
+        peer_socket.write(example_data)
+        peer_socket.close
+
+        expect(stream_socket.read(example_data.size)).to eq example_data
+      end
+    end
+  end
+
+  context "blocking writes" do
+    describe "#writepartial" do
+      it "writes partial data" do
+        # TODO: test the case the write is actually partial
+        expect(stream_socket.writepartial(example_data)).to eq example_data.size
+        expect(peer_socket.read(example_data.size)).to eq example_data
+      end
+    end
+
+    describe "#write" do
+      it "writes complete data" do
+        expect(stream_socket.writepartial(example_data)).to eq example_data.size
+        expect(peer_socket.read(example_data.size)).to eq example_data
+      end
+    end
+  end
+
+  describe "#to_io" do
+    it "converts to a Ruby IO object" do
+      expect(stream_socket.to_io).to be_a(::IO)
+    end
+  end
+end
+
 def unoccupied_port(addr: "localhost", port: 10_000, max_port: 15_000)
   loop do
     begin
@@ -42,4 +114,16 @@ def unoccupied_port(addr: "localhost", port: 10_000, max_port: 15_000)
     port += 1
     raise "exhausted too many ports" if port > max_port
   end
+end
+
+def ssl_cert_dir
+  Pathname.new("../support/ssl").expand_path(__FILE__)
+end
+
+def ssl_cert_path(label)
+  ssl_cert_dir.join(label.to_s + ".crt")
+end
+
+def ssl_key_path(label)
+  ssl_cert_dir.join(label.to_s + ".key")
 end


### PR DESCRIPTION
The initial SSL implementation did not have any specs, and contained some bugs (including potentially security-critical ones)

Specifically, freezing an OpenSSL::SSL::SSLContext can result in unexpected successful verification of invalid certificates. This is arguably a bug in the Ruby OpenSSL extension, and has been reported upstream here:

https://github.com/ruby/openssl/issues/85

The bug was fixed by removing the call to `#freeze`