### PR TITLE
Socketry::TCP::Server#connect_nonblock

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/AbcSize:
   Max: 50
 
 Metrics/ClassLength:
-  Max: 200
+  Max: 250
 
 Metrics/CyclomaticComplexity:
   Max: 15

--- a/lib/socketry/exceptions.rb
+++ b/lib/socketry/exceptions.rb
@@ -4,8 +4,14 @@ module Socketry
   # Generic catch all for all Socketry errors
   Error = Class.new(StandardError)
 
-  # Failed to connect to a remote host
-  ConnectionRefusedError = Class.new(Socketry::Error)
+  # Failed to connect to a host
+  ConnectError = Class.new(Socketry::Error)
+
+  # Remote host confused connection
+  ConnectionRefusedError = Class.new(Socketry::ConnectError)
+
+  # Requested host is down
+  HostDownError = Class.new(Socketry::ConnectError)
 
   # Invalid address
   AddressError = Class.new(Socketry::Error)

--- a/lib/socketry/ssl/socket.rb
+++ b/lib/socketry/ssl/socket.rb
@@ -86,10 +86,7 @@ module Socketry
 
         self
       rescue => ex
-        @socket.close rescue nil
-        @socket = nil
-        @ssl_socket.close rescue nil
-        @ssl_socket = nil
+        close
         raise ex
       end
 
@@ -164,6 +161,8 @@ module Socketry
       # @return [true, false] true if the socket was open, false if closed
       def close
         return false unless super
+        return true unless @ssl_socket
+
         @ssl_socket.close
         @ssl_socket = nil
         true
@@ -173,7 +172,7 @@ module Socketry
 
       # Perform a non-blocking I/O operation
       def perform
-        ensure_connected
+        ensure_state :connected
         yield
       # Some buggy Rubies continue to raise this exception
       rescue IO::WaitWritable

--- a/lib/socketry/tcp/socket.rb
+++ b/lib/socketry/tcp/socket.rb
@@ -7,6 +7,7 @@ module Socketry
     class Socket
       include Socketry::Timeout
 
+      attr_reader :state
       attr_reader :addr_fmaily, :remote_addr, :remote_port, :local_addr, :local_port
       attr_reader :read_timeout, :write_timeout, :resolver, :socket_class
 
@@ -37,86 +38,146 @@ module Socketry
         resolver: Socketry::Resolver::DEFAULT_RESOLVER,
         socket_class: ::Socket
       )
+        @state = :disconnected
+
         @read_timeout = read_timeout
         @write_timeout = write_timeout
 
         @socket_class = socket_class
         @resolver = resolver
-
         @addr_family = nil
         @socket = nil
 
+        @remote_host = nil
         @remote_addr = nil
         @remote_port = nil
         @local_addr  = nil
         @local_port  = nil
 
-        start_timer(timer)
+        start_timer timer
       end
 
       # Connect to a remote host
       #
-      # @param remote_addr  [String]  DNS name or IP address of the host to connect to
-      # @param remote_port  [Fixnum]  TCP port to connect to
-      # @param local_addr   [String]  DNS name or IP address to bind to locally
-      # @param local_port   [Fixnum]  Local TCP port to bind to
-      # @param timeout      [Numeric] Number of seconds to wait before aborting connect
+      # @param remote_host [String]  DNS name or IP address of the host to connect to
+      # @param remote_port [Fixnum]  TCP port to connect to
+      # @param local_addr  [String]  DNS name or IP address to bind to locally
+      # @param local_port  [Fixnum]  Local TCP port to bind to
+      # @param timeout     [Numeric] Number of seconds to wait before aborting connect
       #
       # @raise [Socketry::AddressError] an invalid address was given
       # @raise [Socketry::TimeoutError] connect operation timed out
       #
       # @return [self]
       def connect(
-        remote_addr,
+        remote_host,
         remote_port,
         local_addr: nil,
         local_port: nil,
         timeout: Socketry::Timeout::DEFAULT_TIMEOUTS[:connect]
       )
-        ensure_disconnected
+        ensure_state :disconnected
+
+        begin
+          set_timeout timeout
+
+          remote_addr = @resolver.resolve(remote_host, timeout: time_remaining(timeout))
+          raise ArgumentError, "expected IPAddr from resolver, got #{remote_addr.class}" unless remote_addr.is_a?(IPAddr)
+
+          local_addr = @resolver.resolve(local_addr, timeout: time_remaining(timeout)).to_s if local_addr
+
+          connect_nonblock(remote_addr.to_s, remote_port, local_addr: local_addr, local_port: local_port)
+          @remote_host = remote_host
+
+          return self if connected?
+
+          # Earlier JRuby 9.x versions do not seem to correctly support Socket#wait_writable in this case
+          # Newer versions seem to behave correctly
+          _, writable = IO.select(nil, [@socket], nil, time_remaining(timeout))
+          unless writable && writable.include?(@socket)
+            close
+            raise Socketry::TimeoutError, "connection to #{remote_addr}:#{remote_port} timed out"
+          end
+
+          complete_connect_nonblock
+        ensure
+          clear_timeout timeout
+        end
+
+        self
+      end
+
+      # Initiate a non-blocking connect operation to a remote IP address
+      # DNS resolution is not performed (requires a blocking operation)
+      #
+      # @param remote_ip   [String, IPAddr] IP address of the host to connect to
+      # @param remote_port [Fixnum] TCP port to connect to
+      # @param local_addr  [String, IPAddr] IP address to bind to locally
+      # @param local_port  [Fixnum] Local TCP port to bind to
+      #
+      # @raise [Socketry::AddressError] an invalid address was given
+      #
+      # @return [self, :wait_writable] self if connected, or :wait_writable if still in progress
+      def connect_nonblock(
+        remote_addr,
+        remote_port,
+        local_addr: nil,
+        local_port: nil
+      )
+        ensure_state :disconnected
+
+        # Verify addresses are well-formed
+        begin
+          remote_ipaddr = IPAddr.new(remote_addr)
+          if remote_ipaddr.ipv4?
+            @addr_family = ::Socket::AF_INET
+          elsif remote_ipaddr.ipv6?
+            @addr_family = ::Socket::AF_INET6
+          else raise Socketry::AddressError, "unsupported IP address family: #{remote_ipaddr}"
+          end
+
+          IPAddr.new(local_addr) if local_addr
+        rescue IPAddr::InvalidAddressError
+          raise Socketry::AddressError, "not a valid IP address"
+        end
 
         @remote_addr = remote_addr
         @remote_port = remote_port
         @local_addr  = local_addr
         @local_port  = local_port
 
+        @socket = @socket_class.new(@addr_family, ::Socket::SOCK_STREAM, 0)
+        @socket.bind Addrinfo.tcp(@local_addr, @local_port) if local_addr
+
+        change_state :connecting
+        complete_connect_nonblock
+      end
+
+      # Complete a non-blocking connection which is in progress
+      #
+      # @return [self] self if connected, or :wait_writable if still in progress
+      def complete_connect_nonblock
+        ensure_state :connecting
+
         begin
-          set_timeout(timeout)
-
-          remote_addr = @resolver.resolve(remote_addr, timeout: time_remaining(timeout))
-          local_addr  = @resolver.resolve(local_addr,  timeout: time_remaining(timeout)) if local_addr
-          raise ArgumentError, "expected IPAddr from resolver, got #{remote_addr.class}" unless remote_addr.is_a?(IPAddr)
-
-          @addr_family = if remote_addr.ipv4?    then ::Socket::AF_INET
-                         elsif remote_addr.ipv6? then ::Socket::AF_INET6
-                         else raise Socketry::AddressError, "unsupported IP address family: #{remote_addr}"
-                         end
-
-          socket = @socket_class.new(@addr_family, ::Socket::SOCK_STREAM, 0)
-          socket.bind Addrinfo.tcp(local_addr.to_s, local_port) if local_addr
-          remote_sockaddr = ::Socket.sockaddr_in(remote_port, remote_addr.to_s)
+          remote_sockaddr = ::Socket.sockaddr_in(@remote_port, @remote_addr)
 
           # Note: `exception: false` for Socket#connect_nonblock is only supported in Ruby 2.3+
-          begin
-            socket.connect_nonblock(remote_sockaddr)
-          rescue Errno::ECONNREFUSED => ex
-            raise Socketry::ConnectionRefusedError, "connection to #{remote_addr}:#{remote_port} refused", ex.backtrace
-          rescue Errno::EINPROGRESS, Errno::EALREADY
-            # Earlier JRuby 9.x versions do not seem to correctly support Socket#wait_writable in this case
-            # Newer versions seem to behave correctly
-            retry if IO.select(nil, [socket], nil, time_remaining(timeout))
-
-            socket.close
-            raise Socketry::TimeoutError, "connection to #{remote_addr}:#{remote_port} timed out"
-          rescue Errno::EISCONN
-            # Sometimes raised when we've connected successfully
-          end
-
-          @socket = socket
-        ensure
-          clear_timeout(timeout)
+          # TODO: use `exception: false` when we drop support for Ruby 2.2
+          @socket.connect_nonblock(remote_sockaddr)
+        rescue Errno::ECONNREFUSED
+          close
+          raise Socketry::ConnectionRefusedError, "connection to #{@remote_addr}:#{@remote_port} refused"
+        rescue Errno::EHOSTDOWN
+          close
+          raise Socketry::HostDownError, "cannot connect to #{@remote_addr}: host is down"
+        rescue Errno::EINPROGRESS, Errno::EALREADY
+          return :wait_writable
+        rescue Errno::EISCONN
+          # Sometimes raised when we've connected successfully
         end
 
+        change_state :connected
         self
       end
 
@@ -125,18 +186,27 @@ module Socketry
       # @param timeout [Numeric] Number of seconds to wait before aborting re-connect
       # @raise [Socketry::StateError] not in a disconnected state
       def reconnect(timeout: Socketry::Timeout::DEFAULT_TIMEOUTS[:connect])
-        ensure_disconnected
+        ensure_state :disconnected
         raise StateError, "can't reconnect: never completed initial connection" unless @remote_addr
-        connect(@remote_addr, @remote_port, local_addr: @local_addr, local_port: @local_port, timeout: timeout)
+
+        connect(
+          @remote_host || @remote_addr,
+          @remote_port,
+          local_addr: @local_addr,
+          local_port: @local_port,
+          timeout: timeout
+        )
       end
 
-      # Wrap a Ruby/low-level socket in an Socketry::TCP::Socket
+      # Wrap a connected Ruby/low-level socket in an Socketry::TCP::Socket
       #
       # @param socket [::Socket] (or specified socket_class) low-level socket to wrap
       def from_socket(socket)
-        ensure_disconnected
+        ensure_state :disconnected
         raise TypeError, "expected #{@socket_class}, got #{socket.class}" unless socket.is_a?(@socket_class)
         @socket = socket
+        @state  = :connected
+
         self
       end
 
@@ -149,7 +219,8 @@ module Socketry
       #
       # @return [String, :wait_readable] data read, or :wait_readable if operation would block
       def read_nonblock(size, outbuf: nil)
-        ensure_connected
+        ensure_state :connected
+
         case outbuf
         when String
           @socket.read_nonblock(size, outbuf, exception: false)
@@ -172,7 +243,7 @@ module Socketry
       # @raise [Socketry::Error] an I/O operation failed
       # @return [String, :eof] bytes read, or :eof if socket closed while reading
       def readpartial(size, outbuf: nil, timeout: @read_timeout)
-        set_timeout(timeout)
+        set_timeout timeout
 
         begin
           while (result = read_nonblock(size, outbuf: outbuf)) == :wait_readable
@@ -180,7 +251,7 @@ module Socketry
             raise TimeoutError, "read timed out after #{timeout} seconds"
           end
         ensure
-          clear_timeout(timeout)
+          clear_timeout timeout
         end
 
         result || :eof
@@ -222,7 +293,7 @@ module Socketry
       #
       # @return [Fixnum, :wait_writable] number of bytes written, or :wait_writable if op would block
       def write_nonblock(data)
-        ensure_connected
+        ensure_state :connected
         @socket.write_nonblock(data, exception: false)
       rescue IO::WaitWritable
         # Some buggy Rubies continue to raise this exception
@@ -238,7 +309,7 @@ module Socketry
       # @raise [Socketry::Error] an I/O operation failed
       # @return [Fixnum, :eof] number of bytes written, or :eof if socket closed during writing
       def writepartial(data, timeout: @write_timeout)
-        set_timeout(timeout)
+        set_timeout timeout
 
         begin
           while (result = write_nonblock(data)) == :wait_writable
@@ -246,7 +317,7 @@ module Socketry
             raise TimeoutError, "write timed out after #{timeout} seconds"
           end
         ensure
-          clear_timeout(timeout)
+          clear_timeout timeout
         end
 
         result || :eof
@@ -285,15 +356,15 @@ module Socketry
       # @return [true]  Nagle's algorithm has been explicitly disabled
       # @return [false] Nagle's algorithm is enabled (default)
       def nodelay
-        ensure_connected
+        ensure_state :connected
         @socket.getsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY).int.nonzero?
       end
 
       # Disable or enable Nagle's algorithm
       #
-      # @param flag [true, false] disable or enable coalescing multiple writesusing Nagle's algorithm
+      # @param flag [true, false] disable or enable coalescing multiple writes using Nagle's algorithm
       def nodelay=(flag)
-        ensure_connected
+        ensure_state :connected
         @socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, flag ? 1 : 0)
       end
 
@@ -301,7 +372,7 @@ module Socketry
       #
       # @return [IO] Ruby I/O object
       def to_io
-        ensure_connected
+        ensure_state :connected
         ::IO.try_convert(@socket)
       end
 
@@ -310,10 +381,29 @@ module Socketry
       # @return [true, false] true if the socket was open, false if closed
       def close
         return false if closed?
-        @socket.close
+
+        begin
+          @socket.close
+        rescue Errno::EBADF
+        end
+
         true
       ensure
         @socket = nil
+        change_state :disconnected
+      end
+
+      # Is the socket connected?
+      #
+      # This method returns the local connection state. However, it's possible
+      # the remote side has closed the connection, so it's not actually
+      # possible to actually know if the socket is actually still open without
+      # reading from or writing to it. It's sort of like the Heisenberg
+      # uncertainty principle of sockets.
+      #
+      # @return [true, false] do we locally think the socket is connected?
+      def connected?
+        @state == :connected
       end
 
       # Is the socket closed?
@@ -326,19 +416,50 @@ module Socketry
       #
       # @return [true, false] do we locally think the socket is closed?
       def closed?
-        @socket.nil?
+        @state == :disconnected
       end
 
       private
 
-      def ensure_connected
-        raise StateError, "not connected" if closed?
-        true
+      # Change the current state of the socket to a new state
+      #
+      # @param new_state [:connecting, :connected, :disconnected] new connection state
+      #
+      # @raise  [StateError] illegal state transition requested
+      # @return [self]
+      def change_state(new_state)
+        case new_state
+        when :connecting
+          raise "@socket is unset in #{@state} state" unless @socket
+          raise(StateError, "not in the disconnected state (actual: #{@state})") unless @state == :disconnected
+          @state = :connecting
+        when :connected
+          raise "@socket is unset in #{@state} state" unless @socket
+          raise(StateError, "not in the connecting state (actual: #{@state})") unless @state == :connecting
+          @state = :connected
+        when :disconnected
+          raise "@socket is still set while disconnecting (in #{@state} state)" if @socket
+          raise(StateError, "already in the disconnected state") if @state == :disconnected
+          @state = :disconnected
+        else raise ArgumentError, "bad state argument: #{state.inspect}"
+        end
       end
 
-      def ensure_disconnected
-        return true if closed?
-        raise StateError, "already connected"
+      # Ensure the socket is in a particular state
+      #
+      # @param state [:connecting, :connected, :disconnected] state to assert we're in
+      #
+      # @raise  [StateError] in an unexpected state
+      # @return [true] in expected state
+      def ensure_state(state)
+        return true if state == @state
+
+        case state
+        when :connecting   then raise StateError, "connection not in progress (#{@state})"
+        when :connected    then raise StateError, "not connected"
+        when :disconnected then raise StateError, "already connected"
+        else raise ArgumentError, "bad state argument: #{state.inspect}"
+        end
       end
     end
   end

--- a/spec/socketry/ssl/server_spec.rb
+++ b/spec/socketry/ssl/server_spec.rb
@@ -24,12 +24,14 @@ RSpec.describe Socketry::SSL::Server do
   after  { ssl_server.close rescue nil }
 
   describe "#accept" do
+    let(:timeout) { 1 }
+
     it "accepts connections" do
       begin
         server_thread = Thread.new { ssl_server.accept }
         ssl_client = Socketry::SSL::Socket.new(ssl_params: ssl_client_params)
         ssl_client.connect(bind_addr, bind_port)
-        peer_socket = server_thread.join(1).value
+        peer_socket = server_thread.join(timeout).value
         expect(peer_socket).to be_a Socketry::SSL::Socket
       ensure
         client.close rescue nil

--- a/spec/socketry/tcp/socket_spec.rb
+++ b/spec/socketry/tcp/socket_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Socketry::TCP::Socket do
   it_behaves_like "Socketry stream socket"
 
   let(:remote_host) { "localhost" }
+  let(:remote_addr) { "127.0.0.1" }
   let(:remote_port) { unoccupied_port(addr: remote_host) }
 
   let(:mock_server) { ::TCPServer.new(remote_host, remote_port) }
@@ -31,6 +32,22 @@ RSpec.describe Socketry::TCP::Socket do
         described_class.new.connect(remote_host, unoccupied_port(addr: remote_host))
       end.to raise_error(Socketry::ConnectionRefusedError)
     end
+  end
+
+  describe "#connect_nonblock" do
+    it "initiates non-blocking connect to TCP servers" do
+      expect(described_class.new.connect_nonblock(remote_addr, remote_port)).to eq :wait_writable
+    end
+
+    it "raises Socketry::AddressError if given a hostname instead of an IP address" do
+      expect do
+        described_class.new.connect_nonblock(remote_host, remote_port)
+      end.to raise_error(Socketry::AddressError)
+    end
+  end
+
+  describe "#complete_connect_nonblock" do
+    it "needs tests!"
   end
 
   describe "#reconnect" do


### PR DESCRIPTION
Refactors the current `#connect` method into a separate `#connect` and `#connect_nonblock` methods.