### PR TITLE
Travis: use jruby-9.1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 bundler_args: --without development doc
 
 rvm:
-  - jruby-9.1.6.0
+  - jruby-9.1.8.0
   - 2.2.6
   - 2.3.3
   - 2.4.0


### PR DESCRIPTION
This PR takes us to latest stable JRuby.