### PR TITLE
Fix typo in constant name

### DIFF
--- a/lib/socketry/timeout.rb
+++ b/lib/socketry/timeout.rb
@@ -17,7 +17,7 @@ module Socketry
     # @param timer [#start, #to_f] a timer object (ideally monotonic)
     # @return [true] timer started successfully
     # @raise [Socketry::InternalError] if timer is already started
-    def start_timer(timer = DEFAULT_TIMER_CLASS.new)
+    def start_timer(timer = DEFAULT_TIMER.new)
       raise Socketry::InternalError, "timer already started" if defined?(@timer)
       raise Socketry::InternalError, "deadline already set"  if defined?(@deadline)
 


### PR DESCRIPTION
Fix this error:

```
$ ruby -rsocketry -e 'Class.new do ; include Socketry::Timeout ; end.new.start_timer'
/Users/dentarg/.gem/ruby/2.4.0/gems/socketry-0.5.1/lib/socketry/timeout.rb:20:in `start_timer': uninitialized constant Socketry::Timeout::DEFAULT_TIMER_CLASS (NameError)
Did you mean?  Socketry::Timeout::DEFAULT_TIMER
	from -e:1:in `<main>'
```