### PR TITLE
Travis: jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - gem --version
 
 rvm:
-  - jruby-9.1.17.0
+  - jruby-9.2.0.0
   - 2.2
   - 2.3
   - 2.4.3


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html