### PR TITLE
Travis: add 2.6.0, update to JRuby 9.2.5.0, use rvm aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
 
 rvm:
   - jruby-9.2.5.0
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ before_install:
   - gem --version
 
 rvm:
-  - jruby-9.2.0.0
+  - jruby-9.2.5.0
   - 2.2
   - 2.3
-  - 2.4.3
-  - 2.5.0
+  - 2.4
+  - 2.5
+  - 2.6
 
 matrix:
   fast_finish: true


### PR DESCRIPTION

This PR updates the CI matrix to use latest JRuby, 9.2.5.0.

[JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)

Also: 

  - MRI rubies: point to RVM aliases in https://github.com/rvm/rvm/blob/master/config/known
