### PR TITLE
gemspec: Allow Bundler 2

### DIFF
--- a/socketry.gemspec
+++ b/socketry.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "hitimes", "~> 1.2"
 
-  spec.add_development_dependency "bundler", [">= 1.0", "< 3"]
+  spec.add_development_dependency "bundler"
 end

--- a/socketry.gemspec
+++ b/socketry.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "hitimes", "~> 1.2"
 
-  spec.add_development_dependency "bundler", "~> 1.0"
+  spec.add_development_dependency "bundler", [">= 1.0", "< 3"]
 end


### PR DESCRIPTION
This PR changes the gemspec to allow Bundler 2 to be used - this tries to fix the build.