### PR TITLE
Add test for ArgumentError in UDP socket

### DIFF
--- a/spec/socketry/udp/socket_spec.rb
+++ b/spec/socketry/udp/socket_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Socketry::UDP::Socket do
     it "creates new sockets" do
       expect(described_class.new).to be_a described_class
     end
+
+    it "refuses invalid address families" do
+      expect do
+        described_class.new(addr_family: :foo)
+      end.to raise_error(ArgumentError, "invalid address family: :foo")
+    end
   end
 
   describe "#bind" do


### PR DESCRIPTION
This PR adds a tiny bit of test coverage for argument errors in the UDP socket class.