### PR TITLE
CI: Use jruby-9.2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - gem --version
 
 rvm:
-  - jruby-9.2.8.0
+  - jruby-9.2.9.0
   - 2.3
   - 2.4
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - gem --version
 
 rvm:
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
   - 2.3
   - 2.4
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - gem --version
 
 rvm:
-  - jruby-9.2.7.0
+  - jruby-9.2.8.0
   - 2.3
   - 2.4
   - 2.5


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html)