### PR TITLE
CI: Use JRuby 9.2.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - gem --version
 
 rvm:
-  - jruby-9.2.6.0
+  - jruby-9.2.15.0
   - 2.3
   - 2.4
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - gem --version
 
 rvm:
-  - jruby-9.2.15.0
+  - jruby-9.2.16.0
   - 2.3
   - 2.4
   - 2.5


### PR DESCRIPTION
## Description

This PR updates the CI matrix to use latest JRuby, **9.2.16.0**.

[JRuby 9.2.16.0 release blog post](https://www.jruby.org/2021/03/03/jruby-9-2-16-0.html)

### Types of Changes

- Maintenance.

### Testing

CI change.

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
